### PR TITLE
(impl) added abstract provider

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -23,14 +23,6 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="src" path="target/generated-sources/annotations">
-		<attributes>
-			<attribute name="optional" value="true"/>
-			<attribute name="maven.pomderived" value="true"/>
-			<attribute name="ignore_optional_problems" value="true"/>
-			<attribute name="m2e-apt" value="true"/>
-		</attributes>
-	</classpathentry>
 	<classpathentry kind="src" output="target/classes" path="src/main/java">
 		<attributes>
 			<attribute name="optional" value="true"/>
@@ -44,12 +36,14 @@
 			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry kind="src" path="target/generated-sources/annotations">
+		<attributes>
+			<attribute name="optional" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="src" output="target/test-classes" path="target/generated-test-sources/test-annotations">
 		<attributes>
 			<attribute name="optional" value="true"/>
-			<attribute name="maven.pomderived" value="true"/>
-			<attribute name="ignore_optional_problems" value="true"/>
-			<attribute name="m2e-apt" value="true"/>
 			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>

--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,11 @@
       <artifactId>liquibase-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>ma.glasnost.orika</groupId>
+      <artifactId>orika-core</artifactId>
+      <version>1.5.4</version> <!-- Latest as of July 2025 -->
+    </dependency>
+    <dependency>
       <groupId>org.mybatis.generator</groupId>
       <artifactId>mybatis-generator-core</artifactId>
       <version>1.4.1</version>

--- a/src/main/java/com/prolinkli/core/app/components/buildinfo/provider/BuildInfoProvider.java
+++ b/src/main/java/com/prolinkli/core/app/components/buildinfo/provider/BuildInfoProvider.java
@@ -1,0 +1,15 @@
+package com.prolinkli.core.app.components.buildinfo.provider;
+
+import com.prolinkli.core.app.components.buildinfo.model.BuildInfo;
+import com.prolinkli.core.app.db.model.generated.BuildInfoDb;
+import com.prolinkli.framework.abstractprovider.AbstractProvider;
+
+public class BuildInfoProvider extends AbstractProvider<BuildInfoDb, BuildInfo> {
+
+    @Override
+    public void defineMap(ClassProviderBuilder mapper) {
+        mapper.field("environment", "buildName");
+        mapper.field("version", "buildVersion");
+    }
+  
+}

--- a/src/main/java/com/prolinkli/core/app/components/buildinfo/service/BuildInfoGetService.java
+++ b/src/main/java/com/prolinkli/core/app/components/buildinfo/service/BuildInfoGetService.java
@@ -1,10 +1,8 @@
 package com.prolinkli.core.app.components.buildinfo.service;
 
-import java.time.LocalDate;
-import java.time.ZoneId;
 
 import com.prolinkli.core.app.components.buildinfo.model.BuildInfo;
-import com.prolinkli.core.app.db.mapper.generated.BuildInfoDbMapper;
+import com.prolinkli.core.app.components.buildinfo.provider.BuildInfoProvider;
 import com.prolinkli.core.app.db.model.generated.BuildInfoDb;
 import com.prolinkli.core.app.db.model.generated.BuildInfoDbExample;
 import com.prolinkli.core.app.db.model.generated.BuildInfoDbKey;
@@ -22,6 +20,8 @@ import org.springframework.stereotype.Service;
 public class BuildInfoGetService {
 
 	private final Dao<BuildInfoDb, BuildInfoDbKey> dao;
+
+  private final BuildInfoProvider buildInfoProvider = new BuildInfoProvider();
 
 	@Autowired
 	public BuildInfoGetService(
@@ -63,13 +63,7 @@ public class BuildInfoGetService {
 				.findFirst()
 				.orElseThrow(() -> new RuntimeException("No build info found in the database"));
 
-		BuildInfo buildInfo = new BuildInfo();
-		buildInfo.setBuildName(db.getEnvironment());
-		buildInfo.setBuildVersion(db.getVersion());
-		buildInfo.setCommitHash(db.getCommitHash());
-		buildInfo.setBuildDate(LocalDateUtil.toLocalDate(db.getBuildDate()));
-
-		return buildInfo;
+    return buildInfoProvider.map(db);
 	}
 
 }

--- a/src/main/java/com/prolinkli/core/app/components/user/controller/UserController.java
+++ b/src/main/java/com/prolinkli/core/app/components/user/controller/UserController.java
@@ -1,12 +1,8 @@
 package com.prolinkli.core.app.components.user.controller;
 
 import java.time.LocalDateTime;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
-import com.prolinkli.core.app.Constants.AuthenticationKeys;
-import com.prolinkli.core.app.Constants.Cookies;
 import com.prolinkli.core.app.Constants.LkUserAuthenticationMethods;
 import com.prolinkli.core.app.components.user.model.AuthorizedUser;
 import com.prolinkli.core.app.components.user.model.User;

--- a/src/main/java/com/prolinkli/core/app/components/user/provider/UserPasswordProvider.java
+++ b/src/main/java/com/prolinkli/core/app/components/user/provider/UserPasswordProvider.java
@@ -1,0 +1,13 @@
+package com.prolinkli.core.app.components.user.provider;
+
+import com.prolinkli.core.app.components.user.model.UserPassword;
+import com.prolinkli.core.app.db.model.generated.UserPasswordDb;
+import com.prolinkli.framework.abstractprovider.AbstractProvider;
+
+public class UserPasswordProvider extends AbstractProvider<UserPasswordDb, UserPassword> {
+    @Override
+    public void defineMap(AbstractProvider<UserPasswordDb, UserPassword>.ClassProviderBuilder mapper) {
+        // Map passwordHash <-> password, userId is handled separately
+        mapper.field("passwordHash", "password");
+    }
+} 

--- a/src/main/java/com/prolinkli/core/app/components/user/provider/UserProvider.java
+++ b/src/main/java/com/prolinkli/core/app/components/user/provider/UserProvider.java
@@ -1,0 +1,17 @@
+package com.prolinkli.core.app.components.user.provider;
+
+import com.prolinkli.core.app.components.user.model.User;
+import com.prolinkli.core.app.db.model.generated.UserDb;
+import com.prolinkli.framework.abstractprovider.AbstractProvider;
+
+public class UserProvider extends AbstractProvider<UserDb, User> {
+
+  @Override
+  public void defineMap(AbstractProvider<UserDb, User>.ClassProviderBuilder mapper) {
+    mapper.field("id", "id")
+          .field("username", "username");
+  }
+
+
+  
+}

--- a/src/main/java/com/prolinkli/core/app/components/user/service/UserCreateService.java
+++ b/src/main/java/com/prolinkli/core/app/components/user/service/UserCreateService.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import com.prolinkli.core.app.components.user.model.AuthorizedUser;
 import com.prolinkli.core.app.components.user.model.UserAuthenticationForm;
+import com.prolinkli.core.app.components.user.provider.UserProvider;
 import com.prolinkli.core.app.db.model.generated.UserDb;
 import com.prolinkli.framework.auth.model.AuthProvider;
 import com.prolinkli.framework.db.dao.Dao;
@@ -24,6 +25,8 @@ public class UserCreateService {
   private final List<AuthProvider> authProviders;
 
   private final Dao<UserDb, Long> dao;
+
+  private final UserProvider userProvider = new UserProvider();
 
   @Autowired
   private UserAuthService userAuthService;

--- a/src/main/java/com/prolinkli/core/app/components/user/service/UserGetService.java
+++ b/src/main/java/com/prolinkli/core/app/components/user/service/UserGetService.java
@@ -5,6 +5,8 @@ import java.math.BigInteger;
 import com.prolinkli.core.app.Constants;
 import com.prolinkli.core.app.components.user.model.User;
 import com.prolinkli.core.app.components.user.model.UserPassword;
+import com.prolinkli.core.app.components.user.provider.UserPasswordProvider;
+import com.prolinkli.core.app.components.user.provider.UserProvider;
 import com.prolinkli.core.app.db.model.generated.UserDb;
 import com.prolinkli.core.app.db.model.generated.UserDbExample;
 import com.prolinkli.core.app.db.model.generated.UserPasswordDb;
@@ -20,6 +22,9 @@ public class UserGetService {
 
   private final Dao<UserDb, Long> dao;
   private final Dao<UserPasswordDb, Long> userPasswordDao;
+
+  private final UserProvider userProvider = new UserProvider();
+  private final UserPasswordProvider userPasswordProvider = new UserPasswordProvider();
 
   @Autowired
   public UserGetService(DaoFactory daoFactory) {
@@ -45,11 +50,7 @@ public class UserGetService {
       throw new ResourceNotFoundException("User not found with ID: " + userId);
     }
 
-    User user = new User();
-    user.setId(userDb.getId());
-    user.setUsername(userDb.getUsername());
-
-    return user;
+    return userProvider.map(userDb);
   }
 
   public User getUserByUsername(String username) {
@@ -65,10 +66,7 @@ public class UserGetService {
       throw new ResourceNotFoundException("User not found with username: " + username);
     }
 
-    User user = new User();
-    user.setId(userDb.getId());
-    user.setUsername(userDb.getUsername());
-    return user;
+    return userProvider.map(userDb);
   }
 
   public UserPassword getUserWithPasswordByUsername(String username) {

--- a/src/main/java/com/prolinkli/framework/abstractprovider/AbstractProvider.java
+++ b/src/main/java/com/prolinkli/framework/abstractprovider/AbstractProvider.java
@@ -2,10 +2,13 @@ package com.prolinkli.framework.abstractprovider;
 
 import java.lang.reflect.ParameterizedType;
 import java.util.List;
+import com.prolinkli.framework.abstractprovider.convertor.DateToLocalDateConverter;
 
 
 import lombok.AllArgsConstructor;
 import ma.glasnost.orika.MapperFactory;
+import ma.glasnost.orika.converter.ConverterFactory;
+import ma.glasnost.orika.converter.builtin.DateToStringConverter;
 import ma.glasnost.orika.impl.DefaultMapperFactory;
 import ma.glasnost.orika.metadata.ClassMapBuilder;
 
@@ -22,6 +25,10 @@ public abstract class AbstractProvider<FROM, TO> {
     mapperFactory = new DefaultMapperFactory.Builder()
         .useBuiltinConverters(true)
         .build();
+
+    mapperFactory.getConverterFactory()
+      .registerConverter(new DateToLocalDateConverter());
+
     ClassMapBuilder<FROM, TO> builder = mapperFactory.classMap(fromClass, toClass);
     builder.byDefault();
     ClassProviderBuilder defineMap = new ClassProviderBuilder(builder);
@@ -67,7 +74,7 @@ public abstract class AbstractProvider<FROM, TO> {
     public ClassProviderBuilder field(String fieldA, String fieldB) {
 
       // glass is reversed...
-      classMapBuilder.field(fieldB, fieldA);
+      classMapBuilder.field(fieldA, fieldB);
 
       return this;
     }

--- a/src/main/java/com/prolinkli/framework/abstractprovider/AbstractProvider.java
+++ b/src/main/java/com/prolinkli/framework/abstractprovider/AbstractProvider.java
@@ -3,6 +3,7 @@ package com.prolinkli.framework.abstractprovider;
 import java.lang.reflect.ParameterizedType;
 import java.util.List;
 
+
 import lombok.AllArgsConstructor;
 import ma.glasnost.orika.MapperFactory;
 import ma.glasnost.orika.impl.DefaultMapperFactory;
@@ -11,12 +12,17 @@ import ma.glasnost.orika.metadata.ClassMapBuilder;
 public abstract class AbstractProvider<FROM, TO> {
 
   private final MapperFactory mapperFactory;
+  private Class<FROM> fromClass;
+  private Class<TO> toClass;
 
   public AbstractProvider() {
+    this.fromClass = getFromClass();
+    this.toClass = getToClass();
+
     mapperFactory = new DefaultMapperFactory.Builder()
-      .useBuiltinConverters(true)
-      .build();
-    ClassMapBuilder<FROM, TO> builder =  mapperFactory.classMap(getFromClass(), getToClass());
+        .useBuiltinConverters(true)
+        .build();
+    ClassMapBuilder<FROM, TO> builder = mapperFactory.classMap(fromClass, toClass);
     builder.byDefault();
     ClassProviderBuilder defineMap = new ClassProviderBuilder(builder);
     defineMap(defineMap);
@@ -24,34 +30,33 @@ public abstract class AbstractProvider<FROM, TO> {
   }
 
   public final TO map(FROM from) {
-    return mapperFactory.getMapperFacade().map(from, getToClass());
+    return mapperFactory.getMapperFacade().map(from, toClass);
   }
 
   public final List<TO> mapAll(List<FROM> fromList) {
-    return mapperFactory.getMapperFacade().mapAsList(fromList, getToClass());
+    return mapperFactory.getMapperFacade().mapAsList(fromList, toClass);
   }
 
   public final FROM reverseMap(TO to) {
-    return mapperFactory.getMapperFacade().map(to, getFromClass());
+    return mapperFactory.getMapperFacade().map(to, fromClass);
   }
 
   public final List<FROM> reverseMapAll(List<TO> toList) {
-    return mapperFactory.getMapperFacade().mapAsList(toList, getFromClass());
+    return mapperFactory.getMapperFacade().mapAsList(toList, fromClass);
   }
 
   public abstract void defineMap(ClassProviderBuilder mapper);
 
-  
   @SuppressWarnings("unchecked")
-  private Class<TO> getToClass() {
-    return (Class<TO>) ((ParameterizedType) getClass()
-        .getGenericSuperclass()).getActualTypeArguments()[0];
+  private Class<FROM> getFromClass() {
+    return fromClass == null ? (Class<FROM>) ((ParameterizedType) getClass().getGenericSuperclass())
+        .getActualTypeArguments()[0] : fromClass;
   }
 
   @SuppressWarnings("unchecked")
-  private Class<FROM> getFromClass() {
-    return (Class<FROM>) ((ParameterizedType) getClass()
-        .getGenericSuperclass()).getActualTypeArguments()[1];
+  private Class<TO> getToClass() {
+    return toClass == null ? (Class<TO>) ((ParameterizedType) getClass().getGenericSuperclass())
+        .getActualTypeArguments()[1] : toClass;
   }
 
   @AllArgsConstructor

--- a/src/main/java/com/prolinkli/framework/abstractprovider/AbstractProvider.java
+++ b/src/main/java/com/prolinkli/framework/abstractprovider/AbstractProvider.java
@@ -1,0 +1,72 @@
+package com.prolinkli.framework.abstractprovider;
+
+import java.lang.reflect.ParameterizedType;
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import ma.glasnost.orika.MapperFactory;
+import ma.glasnost.orika.impl.DefaultMapperFactory;
+import ma.glasnost.orika.metadata.ClassMapBuilder;
+
+public abstract class AbstractProvider<FROM, TO> {
+
+  private final MapperFactory mapperFactory;
+
+  public AbstractProvider() {
+    mapperFactory = new DefaultMapperFactory.Builder()
+      .useBuiltinConverters(true)
+      .build();
+    ClassMapBuilder<FROM, TO> builder =  mapperFactory.classMap(getFromClass(), getToClass());
+    builder.byDefault();
+    ClassProviderBuilder defineMap = new ClassProviderBuilder(builder);
+    defineMap(defineMap);
+    builder.register();
+  }
+
+  public final TO map(FROM from) {
+    return mapperFactory.getMapperFacade().map(from, getToClass());
+  }
+
+  public final List<TO> mapAll(List<FROM> fromList) {
+    return mapperFactory.getMapperFacade().mapAsList(fromList, getToClass());
+  }
+
+  public final FROM reverseMap(TO to) {
+    return mapperFactory.getMapperFacade().map(to, getFromClass());
+  }
+
+  public final List<FROM> reverseMapAll(List<TO> toList) {
+    return mapperFactory.getMapperFacade().mapAsList(toList, getFromClass());
+  }
+
+  public abstract void defineMap(ClassProviderBuilder mapper);
+
+  
+  @SuppressWarnings("unchecked")
+  private Class<TO> getToClass() {
+    return (Class<TO>) ((ParameterizedType) getClass()
+        .getGenericSuperclass()).getActualTypeArguments()[0];
+  }
+
+  @SuppressWarnings("unchecked")
+  private Class<FROM> getFromClass() {
+    return (Class<FROM>) ((ParameterizedType) getClass()
+        .getGenericSuperclass()).getActualTypeArguments()[1];
+  }
+
+  @AllArgsConstructor
+  public class ClassProviderBuilder {
+
+    private final ClassMapBuilder<FROM, TO> classMapBuilder;
+
+    public ClassProviderBuilder field(String fieldA, String fieldB) {
+
+      // glass is reversed...
+      classMapBuilder.field(fieldB, fieldA);
+
+      return this;
+    }
+
+  }
+
+}

--- a/src/main/java/com/prolinkli/framework/abstractprovider/convertor/DateToLocalDateConverter.java
+++ b/src/main/java/com/prolinkli/framework/abstractprovider/convertor/DateToLocalDateConverter.java
@@ -1,0 +1,36 @@
+package com.prolinkli.framework.abstractprovider.convertor;
+
+import java.time.DateTimeException;
+import java.time.LocalDate;
+import java.util.Date;
+
+import ma.glasnost.orika.MappingContext;
+import ma.glasnost.orika.converter.BidirectionalConverter;
+import ma.glasnost.orika.metadata.Type;
+
+public class DateToLocalDateConverter extends BidirectionalConverter<LocalDate, Date> {
+
+  @Override
+  public Date convertTo(LocalDate source, Type<Date> destinationType, MappingContext mappingContext) {
+    if (source == null) {
+      return null;
+    }
+    // Convert DateTime to Date
+    return Date.from(source.atStartOfDay().atZone(java.time.ZoneId.systemDefault()).toInstant());
+  }
+
+  @Override
+  public LocalDate convertFrom(Date source, Type<LocalDate> destinationType, MappingContext mappingContext) {
+    if (source == null) {
+      return null;
+    }
+    // Convert Date to LocalDate
+    try {
+      return source.toInstant().atZone(java.time.ZoneId.systemDefault()).toLocalDate();
+    } catch (DateTimeException e) {
+      throw new IllegalArgumentException("Invalid date: " + source, e);
+    }
+  }
+
+  
+}

--- a/src/main/java/com/prolinkli/framework/cookies/util/JwtCookieUtil.java
+++ b/src/main/java/com/prolinkli/framework/cookies/util/JwtCookieUtil.java
@@ -1,7 +1,6 @@
 package com.prolinkli.framework.cookies.util;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import com.prolinkli.core.app.Constants.Cookies;
 import com.prolinkli.framework.config.secrets.SecretsManager;

--- a/src/main/java/com/prolinkli/framework/jwt/provider/AuthTokenProvider.java
+++ b/src/main/java/com/prolinkli/framework/jwt/provider/AuthTokenProvider.java
@@ -1,0 +1,15 @@
+package com.prolinkli.framework.jwt.provider;
+
+import com.prolinkli.core.app.db.model.generated.JwtTokenDb;
+import com.prolinkli.framework.abstractprovider.AbstractProvider;
+import com.prolinkli.framework.jwt.model.AuthToken;
+
+public class AuthTokenProvider extends AbstractProvider<AuthToken, JwtTokenDb> {
+
+    @Override
+    public void defineMap(AbstractProvider<AuthToken, JwtTokenDb>.ClassProviderBuilder mapper) {
+        mapper.field("id", "userId");
+    }
+
+  
+}

--- a/src/main/java/com/prolinkli/framework/jwt/service/JwtCreateService.java
+++ b/src/main/java/com/prolinkli/framework/jwt/service/JwtCreateService.java
@@ -68,9 +68,9 @@ public class JwtCreateService {
     Map<String, Object> finalClaims = MapUtil.merge(userClaims, claims);
 
     AuthToken jwtTokens = createJwtToken(finalClaims);
-    JwtTokenDb jwtTokenDb = authTokenProvider.map(jwtTokens);
+    jwtTokens.setId(user.getId());
 
-    jwtTokenDb.setUserId(user.getId());
+    JwtTokenDb jwtTokenDb = authTokenProvider.map(jwtTokens);
     jwtTokenDb.setExpiresAt(JwtUtil.getExpirationDate(jwtExpiration));
 
     // Save the JWT token in the database

--- a/src/main/java/com/prolinkli/framework/jwt/service/JwtCreateService.java
+++ b/src/main/java/com/prolinkli/framework/jwt/service/JwtCreateService.java
@@ -10,6 +10,7 @@ import com.prolinkli.framework.db.dao.Dao;
 import com.prolinkli.framework.db.dao.DaoFactory;
 import com.prolinkli.framework.jwt.model.AuthToken;
 import com.prolinkli.framework.jwt.model.AuthToken.AuthTokenBuilder;
+import com.prolinkli.framework.jwt.provider.AuthTokenProvider;
 import com.prolinkli.framework.jwt.util.JwtUtil;
 import com.prolinkli.framework.util.map.MapUtil;
 
@@ -33,6 +34,8 @@ public class JwtCreateService {
   private long jwtRefreshExpiration;
 
   private Dao<JwtTokenDb, Long> dao;
+
+  private final AuthTokenProvider authTokenProvider = new AuthTokenProvider();
 
   @Autowired
   public JwtCreateService(DaoFactory daoFactory, SecretsManager secretsManager) {
@@ -65,12 +68,9 @@ public class JwtCreateService {
     Map<String, Object> finalClaims = MapUtil.merge(userClaims, claims);
 
     AuthToken jwtTokens = createJwtToken(finalClaims);
+    JwtTokenDb jwtTokenDb = authTokenProvider.map(jwtTokens);
     jwtTokens.setId(user.getId());
-
-    JwtTokenDb jwtTokenDb = new JwtTokenDb();
     jwtTokenDb.setUserId(user.getId());
-    jwtTokenDb.setAccessToken(jwtTokens.getAccessToken());
-    jwtTokenDb.setRefreshToken(jwtTokens.getRefreshToken());
     jwtTokenDb.setExpiresAt(JwtUtil.getExpirationDate(jwtExpiration));
 
     // Save the JWT token in the database

--- a/src/main/java/com/prolinkli/framework/jwt/service/JwtCreateService.java
+++ b/src/main/java/com/prolinkli/framework/jwt/service/JwtCreateService.java
@@ -69,7 +69,7 @@ public class JwtCreateService {
 
     AuthToken jwtTokens = createJwtToken(finalClaims);
     JwtTokenDb jwtTokenDb = authTokenProvider.map(jwtTokens);
-    jwtTokens.setId(user.getId());
+
     jwtTokenDb.setUserId(user.getId());
     jwtTokenDb.setExpiresAt(JwtUtil.getExpirationDate(jwtExpiration));
 

--- a/start-dev.sh
+++ b/start-dev.sh
@@ -16,5 +16,7 @@ fi
 ./mvnw spring-boot:run \
   -Dspring-boot.run.profiles=local-dev \
   -Dspring-boot.run.jvmArguments="-Xmx1024m -Xms512m \
-  -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005" \
+  -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005 \
+  --add-opens java.base/java.lang=ALL-UNNAMED \
+  --add-opens java.base/java.lang=com.prolinkli.framework " \
   -Dlogging.level.liquibase=DEBUG


### PR DESCRIPTION
This pull request introduces a significant refactor to the codebase by implementing a new `AbstractProvider` class for mapping between database entities and domain models. It also updates various services to use this new provider-based mapping approach, improving code maintainability and reducing redundancy. Additionally, it includes dependency updates, a script modification, and adjustments to the `.classpath` file.

This ticket addressed #14 

### Refactoring and Mapping Improvements:
* Introduced the `AbstractProvider` class in `src/main/java/com/prolinkli/framework/abstractprovider/AbstractProvider.java`, enabling reusable mapping logic between database entities and domain models. This includes support for bidirectional mapping and custom field definitions.
* Added the `DateToLocalDateConverter` in `src/main/java/com/prolinkli/framework/abstractprovider/convertor/DateToLocalDateConverter.java` to handle conversions between `Date` and `LocalDate` during mapping.
* Updated the `BuildInfoGetService`, `UserGetService`, `UserCreateService`, and `Jwt` services to use newly introduced providers (`BuildInfoProvider`, `UserProvider`, `UserPasswordProvider`, and `AuthTokenProvider`) for mapping logic, replacing manual field assignments. [[1]](diffhunk://#diff-d3bedbce2628b76f18fc7c9e81b49f429a2de79d99a17b1734e4ca0c65e35012R24-R25) [[2]](diffhunk://#diff-46d995d3fd41e6cdcf2c475f640b8d395a053c81ccfe5ada7fc6179251a6ff1dR26-R28) [[3]](diffhunk://#diff-d78b29ba3eb891785665496c1a65a47728ffc5f4f4ca7a1441ccc146750dd4f0R29-R30) [[4]](diffhunk://#diff-e9916457403297f677f3b590bd9bf5555854dba3e1b23ecbdedc465286c1d480R38-R39) [[5]](diffhunk://#diff-9001b7ef2eda1d1c9724b6326c517716e883b37da8a654928f24d95c17ab5026R23-R24)

### Dependency Updates:
* Added the `orika-core` library (version 1.5.4) to the `pom.xml` file for object mapping functionality.

### Build and Configuration Adjustments:
* Modified the `.classpath` file to reorganize source paths and attributes, aligning with the updated project structure.
* Updated the `start-dev.sh` script to include `--add-opens` JVM arguments for compatibility with reflective operations in the new mapping framework.